### PR TITLE
feat: Replace White(ish) preset with White

### DIFF
--- a/VU1WPF/ClassDialGUI.cs
+++ b/VU1WPF/ClassDialGUI.cs
@@ -159,7 +159,7 @@ namespace VU1WPF
             new BacklightPresetColor { Name = "Teal",  Red = 0, Green = 100, Blue = 100 },
             new BacklightPresetColor { Name = "Orange",  Red = 100, Green = 10, Blue = 0 },
             new BacklightPresetColor { Name = "Purple",  Red = 100, Green = 10, Blue = 100 },
-            new BacklightPresetColor { Name = "White(ish)",  Red = 100, Green = 30, Blue = 45 }
+            new BacklightPresetColor { Name = "White",  Red = 100, Green = 100, Blue = 100 }
         };
 
         public static List<BacklightPresetColor> AvailablePresets => gBacklightPresets;


### PR DESCRIPTION
The colour presets currently include `White(ish)` which is a sort of slightly pink colour.

Seeing as it's possible to create actual white by setting all the RGB entries to the same value, I think it makes more sense to have an actual White preset - it's likely to be a common colour people want to use and also looks really good.